### PR TITLE
Split Layers

### DIFF
--- a/direct.go
+++ b/direct.go
@@ -4,7 +4,7 @@ type Direct struct {
 	store map[string]any
 }
 
-func NewDirect() Driver {
+func NewDirect() KeyValueLayer {
 	return Direct{
 		store: make(map[string]any),
 	}

--- a/discard.go
+++ b/discard.go
@@ -2,7 +2,7 @@ package silo
 
 type Discard struct{}
 
-func NewDiscard() Driver {
+func NewDiscard() KeyValueLayer {
 	return Discard{}
 }
 

--- a/file.go
+++ b/file.go
@@ -1,7 +1,6 @@
 package silo
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -13,62 +12,26 @@ var (
 )
 
 type File struct {
-	cache    map[string]any
 	filename string
-	dirty    bool
 }
 
-func NewFile(filename string) Driver {
+func NewFile(filename string) DataLayer {
 	return &File{
 		filename: filename,
-		dirty:    true,
-		cache:    make(map[string]any),
 	}
 }
 
-func (f File) Load() error {
-	rawJson, err := os.ReadFile(f.filename)
+func (f File) Read() ([]byte, error) {
+	content, err := os.ReadFile(f.filename)
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrReadFile, err)
+		return nil, fmt.Errorf("%w: %w", ErrReadFile, err)
 	}
-
-	return json.Unmarshal(rawJson, &f.cache)
+	return content, nil
 }
 
-func (f File) Save() error {
-	rawJSON, err := json.Marshal(f.cache)
-	if err != nil {
+func (f File) Write(data []byte) error {
+	if err := os.WriteFile(f.filename, data, 0600); err != nil {
 		return fmt.Errorf("%w: %w", ErrWriteFile, err)
 	}
-
-	if err := os.WriteFile(f.filename, rawJSON, 0600); err != nil {
-		return fmt.Errorf("%w: %w", ErrWriteFile, err)
-	}
-
 	return nil
-}
-
-func (f *File) Get(key string) (any, error) {
-	if f.dirty {
-		if err := f.Load(); err != nil {
-			return nil, err
-		}
-		f.dirty = false
-	}
-
-	value, ok := f.cache[key]
-	if !ok {
-		return nil, ErrKeyNotExist
-	}
-	return value, nil
-}
-
-func (f File) Set(key string, value any) error {
-	f.cache[key] = value
-	return f.Save()
-}
-
-func (f File) Delete(key string) error {
-	delete(f.cache, key)
-	return f.Save()
 }

--- a/json.go
+++ b/json.go
@@ -1,0 +1,37 @@
+package silo
+
+import (
+	"encoding/json"
+)
+
+type Json struct {
+	parent DataLayer
+}
+
+func NewJson(parent DataLayer) FormatLayer {
+	return Json{
+		parent: parent,
+	}
+}
+
+func (j Json) Read() (map[string]any, error) {
+	bytes, err := j.parent.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	var m map[string]any
+	err = json.Unmarshal(bytes, &m)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (j Json) Write(jsonData map[string]any) error {
+	bytes, err := json.Marshal(jsonData)
+	if err != nil {
+		return err
+	}
+	return j.parent.Write(bytes)
+}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,61 @@
+package silo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var ErrWontMarshal = errors.New("I don't like to get marshaled")
+
+type WontMarshal map[string]any
+
+func (w WontMarshal) MarshalJSON() ([]byte, error) {
+	return nil, ErrWontMarshal
+}
+
+type DiscardDataLayer struct{}
+
+func (d DiscardDataLayer) Read() ([]byte, error) {
+	return nil, nil
+}
+func (d DiscardDataLayer) Write(_ []byte) error {
+	return nil
+}
+
+type DirectDataLayer struct {
+	data []byte
+}
+
+func (d DirectDataLayer) Read() ([]byte, error) {
+	return d.data, nil
+}
+func (d *DirectDataLayer) Write(data []byte) error {
+	d.data = data
+	return nil
+}
+
+func TestJsonReadWrite(t *testing.T) {
+	store := NewJson(new(DirectDataLayer))
+	require.NoError(t, store.Write(map[string]any{"a": "bc"}))
+
+	kv, err := store.Read()
+	require.NoError(t, err)
+	require.Equal(t, "bc", kv["a"])
+}
+
+func TestJsonBadDataWrite(t *testing.T) {
+	store := NewJson(DiscardDataLayer{})
+	require.ErrorIs(t, store.Write(map[string]any{"a": WontMarshal{}}), ErrWontMarshal)
+}
+
+func TestJsonBadDataRead(t *testing.T) {
+	ddl := new(DiscardDataLayer)
+	err := ddl.Write([]byte("abc"))
+	require.NoError(t, err)
+
+	store := NewJson(ddl)
+	_, err = store.Read()
+	require.ErrorContains(t, err, "unexpected end of JSON input")
+}

--- a/lock.go
+++ b/lock.go
@@ -11,12 +11,12 @@ var (
 )
 
 type Lock struct {
-	parent Driver
+	parent KeyValueLayer
 	mutex  chan struct{}
 	ctx    context.Context
 }
 
-func NewLock(ctx context.Context, parent Driver) Driver {
+func NewLock(ctx context.Context, parent KeyValueLayer) KeyValueLayer {
 	return Lock{
 		parent: parent,
 		mutex:  make(chan struct{}, 1),

--- a/log.go
+++ b/log.go
@@ -19,11 +19,11 @@ func prettifyErr(err error) string {
 }
 
 type Log struct {
-	parent Driver
+	parent KeyValueLayer
 	file   *os.File
 }
 
-func NewLog(parent Driver, filename string) (Driver, error) {
+func NewLog(parent KeyValueLayer, filename string) (KeyValueLayer, error) {
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("%w %s: %w", ErrOpenLogFile, filename, err)

--- a/log_test.go
+++ b/log_test.go
@@ -8,15 +8,11 @@ import (
 )
 
 func TestLogCRUD(t *testing.T) {
-	f, err := os.CreateTemp("", "dump")
-	require.NoError(t, err)
-	defer os.Remove(f.Name())
-
 	logFile, err := os.CreateTemp("", "log")
 	require.NoError(t, err)
 	defer os.Remove(logFile.Name())
 
-	store, err := NewLog(NewFile(f.Name()), logFile.Name())
+	store, err := NewLog(NewDirect(), logFile.Name())
 	require.NoError(t, err)
 	require.NoError(t, store.Set("a", "b"))
 
@@ -40,6 +36,6 @@ func TestLogCRUD(t *testing.T) {
 }
 
 func TestLogBadFile(t *testing.T) {
-	_, err := NewLog(NewFile("valid"), "/in/val/id")
+	_, err := NewLog(NewDirect(), "/in/val/id")
 	require.ErrorIs(t, err, ErrOpenLogFile)
 }

--- a/readonly.go
+++ b/readonly.go
@@ -7,10 +7,10 @@ var (
 )
 
 type ReadOnly struct {
-	parent Driver
+	parent KeyValueLayer
 }
 
-func NewReadOnly(parent Driver) Driver {
+func NewReadOnly(parent KeyValueLayer) KeyValueLayer {
 	return ReadOnly{
 		parent: parent,
 	}

--- a/readonly_test.go
+++ b/readonly_test.go
@@ -1,7 +1,6 @@
 package silo
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,7 +16,6 @@ func TestReadOnly(t *testing.T) {
 	rawValue, err := store.Get("a")
 	require.NoError(t, err)
 	value, ok := rawValue.(string)
-	fmt.Printf("value: %v\n", rawValue)
 	require.True(t, ok)
 	require.Equal(t, "b", value)
 

--- a/silo.go
+++ b/silo.go
@@ -8,8 +8,18 @@ var (
 	ErrKeyNotExist = errors.New("key doesn't exist")
 )
 
-type Driver interface {
+type KeyValueLayer interface {
 	Set(key string, value any) error
 	Get(key string) (any, error)
 	Delete(key string) error
+}
+
+type FormatLayer interface {
+	Write(data map[string]any) error
+	Read() (map[string]any, error)
+}
+
+type DataLayer interface {
+	Write(data []byte) error
+	Read() ([]byte, error)
 }


### PR DESCRIPTION
Split general layer into three layers:

- `KeyValueLayer`: high level `map[string]any` layers
- `FormatLayer`: conversion between KeyValueLayer's `map[string]any` and DataLayer's `[]byte`
- `DataLayer`: low level `[]byte` for storing data in-memory or external